### PR TITLE
build: unpack only named git deps

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -117,7 +117,7 @@ rec
           submodules = true;
         });
       } // lock;
-    in lib.foldl' (acc: e: if lib.any (oe: (oe.url == e.url) && (oe.key == e.key)) acc then acc else acc ++ [e]) [] (builtins.map mkFetch packageLocks);
+    in builtins.map mkFetch packageLocks;
 
   # A very minimal 'src' which makes cargo happy nonetheless
   dummySrc =


### PR DESCRIPTION
This is an I extension your patch in nix-community/naersk#167. It  no longer removes repeated git repos from the result and then uses this information to only unpack crates that are actually in the lock file. This decreased build time drastically for build with lots of git dependencies.